### PR TITLE
Add tests and process.lines for Scala 2.10

### DIFF
--- a/macros/src/main/scala/ch/jodersky/jni/util/PlatformMacros.scala
+++ b/macros/src/main/scala/ch/jodersky/jni/util/PlatformMacros.scala
@@ -12,7 +12,7 @@ object PlatformMacros {
     import c.universe._
     val result = q"""
       val line = try {
-        scala.sys.process.Process("uname -sm").lineStream.head
+        scala.sys.process.Process("uname -sm").lines.head
       } catch {
         case ex: Exception => sys.error("Error running `uname` command")
       }

--- a/plugin/src/sbt-test/sbt-jni/multiclasses/test
+++ b/plugin/src/sbt-test/sbt-jni/multiclasses/test
@@ -1,2 +1,2 @@
-> javah
-> core/run
+> +javah
+> +core/run

--- a/plugin/src/sbt-test/sbt-jni/oneproject/test
+++ b/plugin/src/sbt-test/sbt-jni/oneproject/test
@@ -1,4 +1,4 @@
-> javah
+> +javah
 $ exists src/native/include/simple_Library__.h
 > nativeInit cmake demo
-> run
+> +run

--- a/plugin/src/sbt-test/sbt-jni/simple/project/ScriptedHelper.scala
+++ b/plugin/src/sbt-test/sbt-jni/simple/project/ScriptedHelper.scala
@@ -7,7 +7,8 @@ object ScriptedHelper extends AutoPlugin {
   override def trigger = allRequirements
 
   override def projectSettings = Seq(
-    crossScalaVersions := Seq("2.11.8", "2.12.0-M4"),
+    scalacOptions ++= Seq("-feature", "-deprecation"),
+    crossScalaVersions := Seq("2.11.8", "2.10.6", "2.12.0-M4"),
     scalaVersion := crossScalaVersions.value.head
   )
 

--- a/plugin/src/sbt-test/sbt-jni/simple/test
+++ b/plugin/src/sbt-test/sbt-jni/simple/test
@@ -1,5 +1,5 @@
-> javah
+> +javah
 $ exists native/src/include/simple_Library__.h
 > nativeInit cmake demo
-> test
-> core/run
+> +test
+> +core/run

--- a/project/SbtJniBuild.scala
+++ b/project/SbtJniBuild.scala
@@ -10,7 +10,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 object SbtJniBuild  extends Build {
 
-  val scalaVersions: Seq[String] = List("2.10.6", "2.11.8", "2.12.0-M4")
+  val scalaVersions: Seq[String] = List("2.11.8", "2.10.6", "2.12.0-M4")
   val macrosParadiseVersion = "2.1.0"
 
   val commonSettings = Seq(


### PR DESCRIPTION
- Add Scala 2.10 in tests and cross-build.
- Use old Process.lines for backwards compatibility