### PR TITLE
Fix warnings from nativeLoaderMacro

### DIFF
--- a/macros/src/main/scala/ch/jodersky/jni/annotations.scala
+++ b/macros/src/main/scala/ch/jodersky/jni/annotations.scala
@@ -40,7 +40,6 @@ class nativeLoaderMacro(val c: Context) {
         val extra = q"""
           {
             def loadPackaged(): Unit = {
-              import java.io.File
               import java.nio.file.{Files, Path}
 
               val lib: String = System.mapLibraryName($nativeLibrary)

--- a/macros/src/main/scala/ch/jodersky/jni/annotations.scala
+++ b/macros/src/main/scala/ch/jodersky/jni/annotations.scala
@@ -47,7 +47,7 @@ class nativeLoaderMacro(val c: Context) {
               val tmp: Path = Files.createTempDirectory("jni-")
               val plat: String = {
                 val line = try {
-                  scala.sys.process.Process("uname -sm").lines.head
+                  scala.sys.process.Process("uname -sm").lineStream.head
                 } catch {
                   case ex: Exception => sys.error("Error running `uname` command")
                 }


### PR DESCRIPTION
When `-deprecation` and `-Ywarn-unused-import` are enabled, using the `@nativeLoader` macro causes the warnings `Unused import` and `method lines in trait ProcessBuilder is deprecated: Use lineStream instead.`

This PR corrects those warnings in the macro definition.