### PR TITLE
Avoid using `uname` except on ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ target in nativeCompile := target.value / "native" / (nativePlatform).value,
 |--------------------------------|---------------|
 | automatic, when JniNative enabled | [JniPackage.scala](plugin/src/main/scala/ch/jodersky/sbt/jni/plugins/JniPackage.scala) |
 
-This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined as the architecture-kernel values returned by `uname -sm`. A native binary of a given platform is assumed to be executable on any machines of the same platform.
+This plugin packages native libraries produced by JniNative in a way that they can be transparently loaded with JniLoad. It uses the notion of a native "platform", defined as the architecture-kernel values returned by `sys.props("os.arch")` and `sys.props("os.name')`.  On ARM-based platforms, where the former fails to provide sufficient granularity, the output of `uname -sm` is used instead. A native binary of a given platform is assumed to be executable on any machines of the same platform.
 
 ## Canonical Use
 
@@ -183,7 +183,7 @@ Real-world use-cases of sbt-jni include:
 ## Requirements and Dependencies
 
 - projects using `JniLoad` must use Scala versions 2.10, 2.11 or 2.12
-- only POSIX platforms are supported (actually, any platform that has the `uname` command available)
+- all platforms are supported (on ARM, the `uname` command is assumed to be available)
 
 The goal of sbt-jni is to be the least intrusive possible. No transitive dependencies are added to projects using any plugin (some dependencies are added to the `provided` configuration, however these do not affect any downstream projects).
 

--- a/macros/src/main/scala/ch/jodersky/jni/annotations.scala
+++ b/macros/src/main/scala/ch/jodersky/jni/annotations.scala
@@ -46,19 +46,23 @@ class nativeLoaderMacro(val c: Context) {
 
               val tmp: Path = Files.createTempDirectory("jni-")
               val plat: String = {
-                val line = try {
-                  scala.sys.process.Process("uname -sm").lines.head
-                } catch {
-                  case ex: Exception => sys.error("Error running `uname` command")
+                val osarch = sys.props("os.arch").toLowerCase.replaceAll("\\s", "")
+                if ("arm" == osarch) {
+                  val line = try {
+                    scala.sys.process.Process("uname -sm").lines.head
+                  } catch {
+                    case ex: Exception => sys.error("Error running `uname` command")
+                  }
+                  val parts = line.split(" ")
+                  if (parts.length != 2) {
+                    sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
+                  } else {
+                    val arch = parts(1).toLowerCase.replaceAll("\\s", "")
+                    val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
+                    arch + "-" + kernel
+                  }
                 }
-                val parts = line.split(" ")
-                if (parts.length != 2) {
-                  sys.error("Could not determine platform: 'uname -sm' returned unexpected string: " + line)
-                } else {
-                  val arch = parts(1).toLowerCase.replaceAll("\\s", "")
-                  val kernel = parts(0).toLowerCase.replaceAll("\\s", "")
-                  arch + "-" + kernel
-                }
+                else osarch + "-" + sys.props("os.name").toLowerCase.replaceAll("\\s", "")
               }
 
               val resourcePath: String = "/native/" + plat + "/" + lib

--- a/plugin/src/main/scala/ch/jodersky/sbt/jni/plugins/JniNative.scala
+++ b/plugin/src/main/scala/ch/jodersky/sbt/jni/plugins/JniNative.scala
@@ -37,7 +37,8 @@ object JniNative extends AutoPlugin {
 
     // the value retruned must match that of `ch.jodersky.jni.PlatformMacros#current()` of project `macros`
     nativePlatform := {
-      try {
+      val osarch = sys.props("os.arch").toLowerCase.replaceAll("\\s", "")
+      if ("arm" == osarch) try {
         val lines = Process("uname -sm").lineStream
         if (lines.length == 0) {
           sys.error("Error occured trying to run `uname`")
@@ -56,7 +57,7 @@ object JniNative extends AutoPlugin {
           sLog.value.error("Error trying to determine platform.")
           sLog.value.warn("Cannot determine platform! It will be set to 'unknown'.")
           "unknown-unknown"
-      }
+      } else osarch + "-" + sys.props("os.name").toLowerCase.replaceAll("\\s", "")
     },
 
     sourceDirectory in nativeCompile := sourceDirectory.value / "native",


### PR DESCRIPTION
In reference to the open issue [Add support for Windows](https://github.com/jodersky/sbt-jni/issues/20), I'm guessing that the long silence and no action following our last exchange implies that a pull request was the preferred way forward; so, here it comes.
