### PR TITLE
Use cmake platform build tool

### DIFF
--- a/plugin/src/main/resources/ch/jodersky/sbt/jni/templates/CMakeLists.txt
+++ b/plugin/src/main/resources/ch/jodersky/sbt/jni/templates/CMakeLists.txt
@@ -5,7 +5,9 @@
 # add/modify/remove settings to build your specific library.   #
 ################################################################
 
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.12)
+
+option(SBT "Set if invoked from sbt-jni" OFF)
 
 # Define project and related variables
 # (required by sbt-jni) please use semantic versioning

--- a/plugin/src/main/scala/ch/jodersky/sbt/jni/build/ConfigureMakeInstall.scala
+++ b/plugin/src/main/scala/ch/jodersky/sbt/jni/build/ConfigureMakeInstall.scala
@@ -16,13 +16,12 @@ trait ConfigureMakeInstall { self: BuildTool =>
     def baseDirectory: File
     def buildDirectory: File
 
-    def clean() = Process("make clean", buildDirectory) ! log
-
     def configure(targetDirectory: File): ProcessBuilder
+    def make(): ProcessBuilder
+    def install(): ProcessBuilder
+    def clean(): Unit
 
-    def make(): ProcessBuilder = Process("make VERBOSE=1", buildDirectory)
-
-    def install(): ProcessBuilder = Process("make install", buildDirectory)
+    def parallelJobs: Int = java.lang.Runtime.getRuntime().availableProcessors()
 
     def library(
       targetDirectory: File

--- a/plugin/src/sbt-test/sbt-jni/multiclasses/native1/src/CMakeLists.txt
+++ b/plugin/src/sbt-test/sbt-jni/multiclasses/native1/src/CMakeLists.txt
@@ -5,7 +5,9 @@
 # add/modify/remove settings to build your specific library.   #
 ################################################################
 
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.12)
+
+option(SBT "Set if invoked from sbt-jni" OFF)
 
 # Define project and related variables
 # (required by sbt-jni) please use semantic versioning

--- a/plugin/src/sbt-test/sbt-jni/multiclasses/native2/src/CMakeLists.txt
+++ b/plugin/src/sbt-test/sbt-jni/multiclasses/native2/src/CMakeLists.txt
@@ -5,7 +5,9 @@
 # add/modify/remove settings to build your specific library.   #
 ################################################################
 
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.12)
+
+option(SBT "Set if invoked from sbt-jni" OFF)
 
 # Define project and related variables
 # (required by sbt-jni) please use semantic versioning

--- a/plugin/src/sbt-test/sbt-jni/simple/project/build.properties
+++ b/plugin/src/sbt-test/sbt-jni/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.4.9


### PR DESCRIPTION
- Don't rely on existence of "make". Use platform's default build tool.
- Use parallel build to speed up compilation. Currently set to number of cores on the machine.

I had to update minimum CMake requirement to 3.12 to have the "parallel" option. Latest CMake version is 3.20, and 3.12+ has been shipped by default on most platforms for a while.
Also added the `option(SBT ...)` to suppress an "error" message for unused variable.

Edit:
Now tries to detect CMake version and will enable parallel flags only if supported.